### PR TITLE
Update shred strategy to improve performance

### DIFF
--- a/bin/shredder
+++ b/bin/shredder
@@ -7,5 +7,5 @@ if [ "$#" -lt 1 ]; then
 fi
 
 set -x
-find "$@" -type f -exec shred --remove {} +
+find "$@" -type f -exec shred --iterations=1 --remove=unlink {} +
 rm -rf "$@"


### PR DESCRIPTION
This commit updates the shred execution strategy to improve overall
performance by overwriting files with less iterations and removing
directories with a system unlink instead of further obfuscation and disk
syncing.

- Shred files with 1 iteration
- Unlink files instead of executing an expensive `wipesync`

> Note ‘wipesync’ is the default method, but can be expensive, requiring
> a sync for every character in every file. This can become significant
> with many files, or is redundant if your file system provides
> synchronous metadata updates.

source: https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html